### PR TITLE
Hubs Foundation docker registry update

### DIFF
--- a/.github/workflows/spoke-RetPageOrigin.yml
+++ b/.github/workflows/spoke-RetPageOrigin.yml
@@ -9,7 +9,7 @@ jobs:
   turkeyGitops:
     uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
       dockerfile: RetPageOriginDockerfile
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}


### PR DESCRIPTION
Use the Hubs Foundation's docker hub repository for building and pushing docker images.