### PR TITLE
[Mozilla Branding Removal] Replace Mozilla Spoke feedback form link with a Discord invite

### DIFF
--- a/src/ui/EditorContainer.js
+++ b/src/ui/EditorContainer.js
@@ -399,7 +399,7 @@ class EditorContainer extends Component {
           },
           {
             name: "Submit Feedback",
-            action: () => window.open("https://forms.gle/2PAFXKwW1SXdfSK17")
+            action: () => window.open("https://discord.gg/wHmY4nd")
           },
           {
             name: "Report an Issue",
@@ -436,7 +436,7 @@ class EditorContainer extends Component {
       },
       {
         name: "Submit Feedback",
-        action: () => window.open("https://forms.gle/2PAFXKwW1SXdfSK17")
+        action: () => window.open("https://discord.gg/wHmY4nd")
       }
     ];
   };


### PR DESCRIPTION
The Submit Feedback buttons in the Spoke project editor main menu (and its Help submenu) currently link to a Google form for sending feedback to Mozilla.  This commit replaces the Mozilla form links with a Discord invite link so feedback about Spoke will come to the Hubs Discord server instead.